### PR TITLE
Small location fix and  other tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,19 +7,23 @@ ENV HOME /app
 
 WORKDIR $APP_HOME
 
-RUN curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s --  -y 
+RUN curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s --  -y
 ENV PATH="${APP_HOME}/.elan/bin:${PATH}"
 
 COPY ./entrypoint.sh /app/entrypoint.sh
-COPY . /app
+COPY lakefile.lean /app/lakefile.lean
+COPY lean-toolchain /app/lean-toolchain
+COPY lake-manifest.json /app/lake-manifest.json
 
-RUN cd /app 
+WORKDIR /app
 
 ENV LEAN_CC "clang++"
-
 RUN lake update
-RUN lake build rinha
 
+COPY Rinha /app/Rinha
+COPY *.lean /app/
+
+RUN lake build rinha
 RUN cp build/bin/rinha /app/rinha
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Rinha/Entities/Person.lean
+++ b/Rinha/Entities/Person.lean
@@ -54,8 +54,8 @@ instance : FromJSON Stack where
 
 def String.toStack? (s : String) : Option (List Stack) :=
    JSON.parse s >>= FromJSON.fromJSON
-  
-def String.parseStack (s: JSON) : Option (List Stack) := 
+
+def String.parseStack (s: JSON) : Option (List Stack) :=
   FromJSON.fromJSON s
 
 /--
@@ -67,9 +67,9 @@ instance : Ash.ToJSON Stack where
   toJSON stack := Ash.JSON.str stack.data
 
 instance [Ash.ToJSON t]: Ash.ToJSON (Option t) where
-  toJSON 
+  toJSON
     | none   => JSON.null
-    | some x => ToJSON.toJSON x 
+    | some x => ToJSON.toJSON x
 
 /--
 The *basic* type of a person. It contains it's name and other info
@@ -84,7 +84,7 @@ structure Person where
   deriving Repr
 
 instance : Ash.ToJSON Person where
-  toJSON person := 
+  toJSON person :=
      `{ "id"         +: person.id
       , "apelido"    +: person.username.data
       , "nome"       +: person.name.data
@@ -134,7 +134,7 @@ def countPeople (conn : Connection) : IO Nat := do
   let result ← exec conn "SELECT COUNT(id) FROM users;" #[]
   match result with
   | Except.error _ => return 0
-  | Except.ok rs => 
+  | Except.ok rs =>
     match rs.get? 0 with
     | some res => return (res.get "count").get!
     | none     => return 0
@@ -144,7 +144,7 @@ def Person.create! (person : Person) (conn : Connection) : IO (Option Person) :=
   let stack := ToJSON.toJSON person.stack
 
   -- Make the query
-  let result ← exec conn "INSERT INTO users (username, name, birth_date, stack, search) VALUES ($1, $2, $3, $4, $5) RETURNING id, username, name, birth_date, stack;" 
+  let result ← exec conn "INSERT INTO users (username, name, birth_date, stack, search) VALUES ($1, $2, $3, $4, $5) RETURNING id, username, name, birth_date, stack;"
     #[ person.username.data
     ,  person.name.data
     ,  person.birthdate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '3.5'
 services:
   api1: # API - Instância 01
-    image: gabrielleeg1/rinha:latest
+    # image: gabrielleeg1/rinha:latest
+    build: .
     hostname: api1
     depends_on:
       db:
@@ -25,7 +26,8 @@ services:
           memory: '0.5GB'
 
   api2:
-    image: gabrielleeg1/rinha:latest
+    # image: gabrielleeg1/rinha:latest
+    build: .
     hostname: api2
     depends_on:
         db:
@@ -68,8 +70,8 @@ services:
    environment:
       POSTGRES_PASSWORD: 'password'
       POSTGRES_DB: 'rinha'
-   ports:
-      - "5432:5432"
+   expose:
+      - "5432"
    volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
    deploy:


### PR DESCRIPTION
There was a small bug in the location path generation. The Option person.id was not being matched, and the resulting path was /pessoas/(some ...). The stress test was mass failing on the 'consulta' section, but no one noticed because the criteria was just a total of inserts.

Congratulations on one of the best versions of the Rinha. This is most impressive.